### PR TITLE
Add compensation rule and a few more swear words

### DIFF
--- a/lib/recruiter_lint/rules/compensation.rb
+++ b/lib/recruiter_lint/rules/compensation.rb
@@ -1,0 +1,22 @@
+module RecruiterLint
+  module Rules
+    class Compensation < Rule
+      name "Compensation"
+      desc "Don't discuss compensation - it seems desperate."
+
+      def run(spec, result)
+        comp_words = [
+          "pay", "bonus", "stock", "salary", "shares",
+          "equity", "options", "compensation"
+        ]
+
+        comp_mentions = spec.contains?(comp_words)
+
+        if comp_mentions.any?
+          result.add_warning "Unless this is an offer email, don't discuss compensation", comp_mentions
+          result.add_recruiter_fail_points comp_mentions.length
+        end
+      end
+    end
+  end
+end

--- a/lib/recruiter_lint/rules/profanity.rb
+++ b/lib/recruiter_lint/rules/profanity.rb
@@ -7,8 +7,8 @@ module RecruiterLint
 
       def run(spec, result)
         swears = [
-          "bloody", "bugger", "cunt", "shit",
-          /fuck(?:er|ing)?/i, /piss(?:ing)?/i
+          "bloody", "bugger", "cunt", "shit", "damn", "ass", "crap",
+          /fuck(?:er|ing)?/i, /piss(?:ing)?/i, /bitch(?:es|ing)?/i
         ]
 
         swear_mentions = spec.contains?(swears)


### PR DESCRIPTION
Mentioning compensation in a recruiter email screams desperation and even if it works, the candidates you source likely aren't interested for the right reasons.

I also added a couple of other profane words.
